### PR TITLE
fix: correct blog date

### DIFF
--- a/blog/GoErrorHanding.md
+++ b/blog/GoErrorHanding.md
@@ -1,6 +1,7 @@
 ---
 slug: Go error handing
 title: Go 错误处理 - 最佳实践
+date: 2022-04-24
 author: Shixu
 author_title: Owner
 author_image_url: https://avatars.githubusercontent.com/u/25247325

--- a/blog/MavenSummary.md
+++ b/blog/MavenSummary.md
@@ -1,6 +1,7 @@
 ---
 slug: Maven Summary
 title: Maven Summary
+date: 2022-01-01
 author: Shixu
 author_title: Owner
 author_image_url: https://avatars.githubusercontent.com/u/25247325

--- a/blog/Mvnd.md
+++ b/blog/Mvnd.md
@@ -1,6 +1,7 @@
 ---
 slug: Mvnd vs Maven
 title: Mvnd vs Maven
+date: 2022-01-03
 author: Shixu
 author_title: Owner
 author_image_url: https://avatars.githubusercontent.com/u/25247325


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only changes to markdown frontmatter; no application logic or runtime behavior changes.
> 
> **Overview**
> Adds `date` frontmatter to three existing blog posts (Go error handling, Maven summary, and Mvnd vs Maven) to ensure correct publication metadata/display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2de48893b04e245403e55c0fc8b3a622d4de93c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->